### PR TITLE
Update client/config.ui

### DIFF
--- a/client/config.ui
+++ b/client/config.ui
@@ -68,7 +68,7 @@
     </rect>
    </property>
    <property name="title">
-    <string>Code share</string>
+    <string>Code share:</string>
    </property>
    <property name="checkable">
     <bool>false</bool>


### PR DESCRIPTION
Missing colon mark added in the end of "Code Share" label.
